### PR TITLE
Add ability to provide extra arguments to adjoin

### DIFF
--- a/manifests/adjoin/keytab.pp
+++ b/manifests/adjoin/keytab.pp
@@ -11,6 +11,7 @@ class centrify::adjoin::keytab {
   $_domain     = $::centrify::domain
   $_container  = $::centrify::container
   $_zone       = $::centrify::zone
+  $_extra_args = $::centrify::extra_args
 
   file { 'krb_keytab':
     path   => $_krb_keytab,
@@ -48,12 +49,12 @@ class centrify::adjoin::keytab {
   if $_zone {
     $_default_join_opts = ['--force', '-V']
     $_zone_opt = "-z '${_zone}'"
-    $_join_opts = delete(concat($_default_join_opts, $_zone_opt, $_container_opt), '')
+    $_join_opts = delete(concat($_default_join_opts, $_zone_opt, $_container_opt, $_extra_args), '')
     $_options = join($_join_opts, ' ')
     $_command = "adjoin ${_options} '${_domain}'"
   } else {
     $_default_join_opts = ['--force', '-w']
-    $_join_opts = delete(concat($_default_join_opts, $_container_opt), '')
+    $_join_opts = delete(concat($_default_join_opts, $_container_opt, $_extra_args), '')
     $_options = join($_join_opts, ' ')
     $_command = "adjoin ${_options} '${_domain}'"
   }

--- a/manifests/adjoin/password.pp
+++ b/manifests/adjoin/password.pp
@@ -5,11 +5,12 @@
 #
 class centrify::adjoin::password {
 
-  $_user      = $::centrify::join_user
-  $_password  = $::centrify::join_password
-  $_domain    = $::centrify::domain
-  $_container = $::centrify::container
-  $_zone      = $::centrify::zone
+  $_user       = $::centrify::join_user
+  $_password   = $::centrify::join_password
+  $_domain     = $::centrify::domain
+  $_container  = $::centrify::container
+  $_zone       = $::centrify::zone
+  $_extra_args = $::centrify::extra_args
 
   $_default_join_opts = ["-u '${_user}'", "-p '${_password}'"]
 
@@ -21,11 +22,11 @@ class centrify::adjoin::password {
 
   if $_zone {
     $_zone_opt = "-z '${_zone}'"
-    $_join_opts = delete(concat($_default_join_opts, $_zone_opt, $_container_opt), '')
+    $_join_opts = delete(concat($_default_join_opts, $_zone_opt, $_container_opt, $_extra_args), '')
     $_options = join($_join_opts, ' ')
     $_command = "adjoin -V ${_options} '${_domain}'"
   } else {
-    $_join_opts = delete(concat($_default_join_opts, $_container_opt), '')
+    $_join_opts = delete(concat($_default_join_opts, $_container_opt, $_extra_args), '')
     $_options = join($_join_opts, ' ')
     $_command = "adjoin -w ${_options} '${_domain}'"
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class centrify (
   $flush_cronjob_monthday = $::centrify::params::flush_cronjob_monthday,
   $flush_cronjob_month    = $::centrify::params::flush_cronjob_month,
   $flush_cronjob_weekday  = $::centrify::params::flush_cronjob_weekday,
-
+  $extra_args             = $::centrify::params::extra_args,
 ) inherits ::centrify::params {
 
   if $krb_ticket_join == false {
@@ -73,6 +73,7 @@ class centrify (
   if $use_express_license   { validate_bool($use_express_license) }
   if $install_flush_cronjob { validate_bool($install_flush_cronjob) }
   if $sshd_service_enable   { validate_bool($sshd_service_enable) }
+  if $extra_args            { validate_array($extra_args) }
 
   if $install_flush_cronjob {
     validate_string(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,4 +52,5 @@ class centrify::params {
   $flush_cronjob_monthday = '*'
   $flush_cronjob_month    = '*'
   $flush_cronjob_weekday  = '*'
+  $extra_args             = undef
 }

--- a/spec/classes/adjoin__keytab_spec.rb
+++ b/spec/classes/adjoin__keytab_spec.rb
@@ -117,6 +117,20 @@ describe 'centrify' do
               })
             end
           end
+
+          context 'with extra_args set' do
+            let(:params) do
+              super().merge({
+                :extra_args => [ '--name foobar' ],
+              })
+            end
+
+            it do
+              is_expected.to contain_exec('run_adjoin_with_keytab').with({
+                'command' => "adjoin --force -w --name foobar 'example.com'",
+              })
+            end
+          end
         end
       end
     end

--- a/spec/classes/adjoin__password_spec.rb
+++ b/spec/classes/adjoin__password_spec.rb
@@ -62,6 +62,20 @@ describe 'centrify' do
               })
             end
           end
+
+          context 'with extra_args set' do
+            let(:params) do
+              super().merge({
+                :extra_args => [ '--name foobar' ],
+              })
+            end
+
+            it do
+              is_expected.to contain_exec('adjoin_with_password').with({
+                'command' => "adjoin -w -u 'user' -p 'password' --name foobar 'example.com'",
+              })
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
* Add a new parameter called 'extra_args' that accepts an array of extra
arguments to pass to the 'adjoin' command on precreate and join.

In our use case, we need the ability to specify extra arguments to the `adjoin` command(s).  Specifically, the ability to specify the computer name (`-N` or `--name`).  I'm not sure if this is something you'd like to support in the module or not and how you'd prefer to go about it.  I've added a parameter called `extra_args` to pass along to the adjoin commands, which would accept arbitrary user-provided arguments.  Not sure how you feel about that or if you'd prefer to map `adjoin` arguments/options to parameters.  Happy to make any adjustments.