### PR TITLE
Add 'precreate' option; add `extra_args` to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,6 +55,7 @@ It also manages the Centrify DC agent and OpenSSH daemons.
         * the `kinit` command is run to obtain an initial TGT
         * the `adjoin` command is run to join via keytab
     * the `adflush` and `adreload` commands are run post-join
+    * the `adjoin` command is run to precreate computer and extension objects if `precreate => true`
     * the `adlicense --express` command is run if `use_express_license => true` (the default) and licensed features are enabled
 
 ### Setup Requirements
@@ -122,7 +123,7 @@ Set up Centrify Express and join an Active Directory domain via a keytab (initia
 
 ###Parameters
 
-* `dc_package_name`: String. Name of the centrifydc package. 
+* `dc_package_name`: String. Name of the centrifydc package.
 * `sshd_package_name`: String. Name of the centrifydc-openssh package.
 * `dc_package_ensure`: String. Set to 'present' or 'absent'.
 * `sshd_package_ensure`: String. Set to 'present' or 'absent'.
@@ -148,7 +149,7 @@ Set up Centrify Express and join an Active Directory domain via a keytab (initia
 * `krb_keytab`: String. Absolute path to the keytab file used to join the domain.
 * `initialize_krb_config`: Boolean. Whether to initialize `krb_config_file` with the contents of `krb_config`.
 * `krb_config`: Hash. Configuration used to initialize `krb_config_file` for performing a keytab join.
-* `zone`: String. Name of the zone in which to place the computer account. 
+* `zone`: String. Name of the zone in which to place the computer account.
 * `container`: String. LDAP path to the OU container in which to place the computer account.
 * `use_express_license`: Boolean. If true, set the adlicense to `express` if licensed features are enabled.
 * `install_flush_cronjob`: Boolean. Whether to install a cronjob that flushes and reloads Centrify.
@@ -157,6 +158,8 @@ Set up Centrify Express and join an Active Directory domain via a keytab (initia
 * `flush_cronjob_monthday`: String. Cron day of month for flush and reload cronjob.
 * `flush_cronjob_month`: String. Cron month for flush and reload cronjob.
 * `flush_cronjob_weekday`: String. Cron day of week for flush and reload cronjob.
+* `extra_args`: Array. Array of extra arguments to pass to the `adjoin` command.
+* `precreate`: Boolean. If true, `adjoin` will run to precreate the computer and extension object in AD prior to joining.
 
 
 ###Types

--- a/manifests/adjoin/password.pp
+++ b/manifests/adjoin/password.pp
@@ -11,6 +11,7 @@ class centrify::adjoin::password {
   $_container  = $::centrify::container
   $_zone       = $::centrify::zone
   $_extra_args = $::centrify::extra_args
+  $_precreate  = $::centrify::precreate
 
   $_default_join_opts = ["-u '${_user}'", "-p '${_password}'"]
 
@@ -29,6 +30,16 @@ class centrify::adjoin::password {
     $_join_opts = delete(concat($_default_join_opts, $_container_opt, $_extra_args), '')
     $_options = join($_join_opts, ' ')
     $_command = "adjoin -w ${_options} '${_domain}'"
+  }
+
+  if $_precreate {
+    $_precreate_command = "${_command} -P"
+    exec { 'adjoin_precreate_with_password':
+      path    => '/usr/bin:/usr/sbin:/bin',
+      command => $_precreate_command,
+      unless  => "adinfo -d | grep ${_domain}",
+      before  => Exec['adjoin_with_password'],
+    }
   }
 
   exec { 'adjoin_with_password':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class centrify (
   $flush_cronjob_month    = $::centrify::params::flush_cronjob_month,
   $flush_cronjob_weekday  = $::centrify::params::flush_cronjob_weekday,
   $extra_args             = $::centrify::params::extra_args,
+  $precreate              = $::centrify::params::precreate,
 ) inherits ::centrify::params {
 
   if $krb_ticket_join == false {
@@ -74,6 +75,7 @@ class centrify (
   if $install_flush_cronjob { validate_bool($install_flush_cronjob) }
   if $sshd_service_enable   { validate_bool($sshd_service_enable) }
   if $extra_args            { validate_array($extra_args) }
+  if $precreate             { validate_bool($precreate) }
 
   if $install_flush_cronjob {
     validate_string(

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,4 +53,5 @@ class centrify::params {
   $flush_cronjob_month    = '*'
   $flush_cronjob_weekday  = '*'
   $extra_args             = undef
+  $precreate              = false
 }

--- a/spec/classes/adjoin__keytab_spec.rb
+++ b/spec/classes/adjoin__keytab_spec.rb
@@ -88,10 +88,9 @@ describe 'centrify' do
 
           it do
             is_expected.to contain_exec('run_adjoin_with_keytab').with({
-              'path'        => '/usr/bin:/usr/sbin:/bin',
-              'command'     => "adjoin --force -w 'example.com'",
-              'unless'      => 'adinfo -d | grep example.com',
-              'refreshonly' => 'true',
+              'path'    => '/usr/bin:/usr/sbin:/bin',
+              'command' => "adjoin --force -w 'example.com'",
+              'unless'  => 'adinfo -d | grep example.com',
             })
           end
 
@@ -128,6 +127,20 @@ describe 'centrify' do
             it do
               is_expected.to contain_exec('run_adjoin_with_keytab').with({
                 'command' => "adjoin --force -w --name foobar 'example.com'",
+              })
+            end
+          end
+
+          context 'with precreate set' do
+            let(:params) do
+              super().merge({
+                :precreate => true,
+              })
+            end
+
+            it do
+              is_expected.to contain_exec('run_adjoin_precreate_with_keytab').with({
+                'command' => "adjoin --force -w 'example.com' -P",
               })
             end
           end

--- a/spec/classes/adjoin__password_spec.rb
+++ b/spec/classes/adjoin__password_spec.rb
@@ -76,6 +76,20 @@ describe 'centrify' do
               })
             end
           end
+
+          context 'with precreate set' do
+            let(:params) do
+              super().merge({
+                :precreate => true,
+              })
+            end
+
+            it do
+              is_expected.to contain_exec('adjoin_precreate_with_password').with({
+                'command' => "adjoin -w -u 'user' -p 'password' 'example.com' -P",
+              })
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
This re-opens PR #5 - rebased to clean it up

* Add a new parameter called 'precreate' that accepts a boolean to
determine if 'adinfo' should precreate computer and extension object.
This defaults to false.  If true, this will run prior to joining.

* Remove the 'refreshonly' on `Exec[run_kinit_with_keytab]` and
`Exec[run_adjoin_precreate_with_keytab]`.  These resources don't
consistently seem to get a refresh event, which causes them not to be
applied.  They do have an `unless` specified, providing idempotency.

* Adds the `extra_args` parameter from PR #6 to the readme