### PR TITLE
Use environment variable for join password

### DIFF
--- a/manifests/adjoin/password.pp
+++ b/manifests/adjoin/password.pp
@@ -33,7 +33,7 @@ class centrify::adjoin::password (
     '-V',
     $_zone_opt,
     "-u '${join_user}'",
-    "-p '${join_password}'",
+    '-p $CENTRIFY_JOIN_PASSWORD',
     $_container_opt,
     $_server_opt,
   ]
@@ -44,18 +44,20 @@ class centrify::adjoin::password (
 
   if $precreate {
     exec { 'adjoin_precreate_with_password':
-      path    => '/usr/bin:/usr/sbin:/bin',
-      command => "${_command} -P",
-      unless  => "adinfo -d | grep ${domain}",
-      before  => Exec['adjoin_with_password'],
+      path        => '/usr/bin:/usr/sbin:/bin',
+      command     => "${_command} -P",
+      environment => "CENTRIFY_JOIN_PASSWORD='${join_password}'",
+      unless      => "adinfo -d | grep ${domain}",
+      before      => Exec['adjoin_with_password'],
     }
   }
 
   exec { 'adjoin_with_password':
-    path    => '/usr/bin:/usr/sbin:/bin',
-    command => $_command,
-    unless  => "adinfo -d | grep ${domain}",
-    notify  => Exec['run_adflush_and_adreload'],
+    path        => '/usr/bin:/usr/sbin:/bin',
+    command     => $_command,
+    environment => "CENTRIFY_JOIN_PASSWORD='${join_password}'",
+    unless      => "adinfo -d | grep ${domain}",
+    notify      => Exec['run_adflush_and_adreload'],
   }
 
   exec { 'run_adflush_and_adreload':

--- a/spec/classes/adjoin__password_spec.rb
+++ b/spec/classes/adjoin__password_spec.rb
@@ -22,9 +22,10 @@ describe 'centrify' do
 
           it do
             is_expected.to contain_exec('adjoin_with_password').with({
-              'path'    => '/usr/bin:/usr/sbin:/bin',
-              'command' => "adjoin -V -w -u 'user' -p 'password' 'example.com'",
-              'unless'  => 'adinfo -d | grep example.com',
+              'path'        => '/usr/bin:/usr/sbin:/bin',
+              'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com'",
+              'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+              'unless'      => 'adinfo -d | grep example.com',
             })
           end
 
@@ -45,7 +46,8 @@ describe 'centrify' do
 
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
-                'command' => "adjoin -V -z 'ZONE' -u 'user' -p 'password' 'example.com'",
+                'command'     => "adjoin -V -z 'ZONE' -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
               })
             end
           end
@@ -59,7 +61,8 @@ describe 'centrify' do
 
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
-                'command' => "adjoin -V -w -u 'user' -p 'password' -c 'ou=Unix computers' 'example.com'",
+                'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD -c 'ou=Unix computers' 'example.com'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
               })
             end
           end
@@ -73,7 +76,8 @@ describe 'centrify' do
 
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
-                'command' => "adjoin -V -w -u 'user' -p 'password' --name foobar 'example.com'",
+                'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD --name foobar 'example.com'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
               })
             end
           end
@@ -87,7 +91,8 @@ describe 'centrify' do
 
             it do
               is_expected.to contain_exec('adjoin_precreate_with_password').with({
-                'command' => "adjoin -V -w -u 'user' -p 'password' 'example.com' -P",
+                'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com' -P",
+                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
               })
             end
           end


### PR DESCRIPTION
* Specify the join password as an environment variable on the Exec
resources, and reference the environment variable in the join commands
to redact the password from Puppet's output (e.g. on failure, the Exec
resource will display the failed command).

* Long-term, Puppet's `Sensitive` data type can be used for redaction on
the Exec output, but it looks like that's only recently been added
(Puppet 4.10.0):
https://tickets.puppetlabs.com/browse/PUP-6494