### PR TITLE
Optionally manage Centrify sshd_config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .*.sw?
 /pkg
-/spec/fixtures
+/spec/fixtures/**
+!/spec/fixtures/modules/
+!/spec/fixtures/modules/test/
+!/spec/fixtures/modules/test/**
 /.rspec_system
 /.vagrant
 /.bundle

--- a/README.markdown
+++ b/README.markdown
@@ -121,7 +121,7 @@ Set up Centrify Express and join an Active Directory domain via a keytab (initia
 
 ## Reference
 
-###Parameters
+### Parameters
 
 * `dc_package_name`: String. Name of the centrifydc package.
 * `sshd_package_name`: String. Name of the centrifydc-openssh package.
@@ -161,12 +161,16 @@ Set up Centrify Express and join an Active Directory domain via a keytab (initia
 * `flush_cronjob_weekday`: String. Cron day of week for flush and reload cronjob.
 * `extra_args`: Array. Array of extra arguments to pass to the `adjoin` command.
 * `precreate`: Boolean. If true, `adjoin` will run to precreate the computer and extension object in AD prior to joining.
+* `manage_sshd_config`: Boolean. Specifies whether the Centrify SSH config (`sshd_config_file`) should be managed. Default is true.
+* `sshd_config_content`: String, Hash, or Array. Contents of the `sshd_config_file`. Mutually exclusive with `sshd_config_source`. `sshd_config_template` takes precedence if it's specified, and this parameter can be referenced within a custom template.
+* `sshd_config_template`: String. Passed to the `template()` function for the value of the `content` parameter for `sshd_config_file` resource when `manage_sshd_config=true`. Mutually exclusive with `sshd_config_source`. Both `sshd_config_content` and `sshd_config_template` can be specified, but the template takes precedence. The `sshd_config_content` parameter can be referenced in a custom template via a local scope variable of the same name.
+* `sshd_config_source`: String. Value for the `source` parameter for the `sshd_config_file` resource when `manage_sshd_config=true`. Mutually exclusive with `sshd_config_content` and `sshd_config_template`
 
 
-###Types
+### Types
 * `centrifydc_line`: Set configuration directives in the centrifydc.conf file.
 
-###Classes
+### Classes
 * centrify::install
 * centrify::config
 * centrify::service

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,6 +15,7 @@ centrify::initialize_krb_config: false
 centrify::use_express_license: false
 centrify::install_flush_cronjob: false
 centrify::precreate: false
+centrify::manage_sshd_config: true
 centrify::extra_args: []
 centrify::krb_config: {}
 centrify::dc_config_file: '/etc/centrifydc/centrifydc.conf'
@@ -35,5 +36,8 @@ centrify::join_user: ~
 centrify::join_password: ~
 centrify::selfserve_rodc: ~
 centrify::zone: ~
+centrify::sshd_config_content: ~
+centrify::sshd_config_template: ~
+centrify::sshd_config_source: ~
 centrify::krb_keytab: ~
 centrify::join_type: 'password'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,12 @@ class centrify::config {
   $_allow_groups        = $::centrify::allow_groups
   $_deny_users          = $::centrify::deny_users
   $_deny_groups         = $::centrify::deny_groups
+  $sshd_config_content  = $::centrify::sshd_config_content
+
+  $_sshd_config_content_param = $::centrify::sshd_config_template ? {
+    undef   => $::centrify::sshd_config_content,
+    default => template($::centrify::sshd_config_template),
+  }
 
   file { 'centrifydc_config':
     ensure => file,
@@ -16,12 +22,16 @@ class centrify::config {
     mode   => '0644',
   }
 
-  file { 'centrifydc_sshd_config':
-    ensure => $::centrify::sshd_config_ensure,
-    path   => $::centrify::sshd_config_file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0600',
+  if $::centrify::manage_sshd_config {
+    file { 'centrifydc_sshd_config':
+      ensure  => $::centrify::sshd_config_ensure,
+      path    => $::centrify::sshd_config_file,
+      content => $_sshd_config_content_param,
+      source  => $::centrify::sshd_config_source,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0600',
+    }
   }
 
   if $_allow_users {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class centrify (
   Boolean $use_express_license,
   Boolean $install_flush_cronjob,
   Boolean $precreate,
+  Boolean $manage_sshd_config,
   Array $extra_args,
   Hash $krb_config,
   Stdlib::Absolutepath $dc_config_file,
@@ -46,6 +47,9 @@ class centrify (
   Optional[String] $join_password,
   Optional[String] $selfserve_rodc,
   Optional[String] $zone,
+  Optional[String] $sshd_config_template,
+  Optional[String] $sshd_config_source,
+  Optional[Variant[String, Hash, Array]] $sshd_config_content,
   Optional[Stdlib::Absolutepath] $krb_keytab,
   Enum['selfserve', 'password', 'keytab'] $join_type,
 ){
@@ -57,6 +61,9 @@ class centrify (
   }
   if ($initialize_krb_config and empty($krb_config)) {
     fail('Cannot set initialize_krb_config without krb_config')
+  }
+  if ($sshd_config_source and ($sshd_config_content or $sshd_config_template)) {
+    fail('Cannot set sshd_config_source and sshd_config_content or sshd_config_template')
   }
 
   class { '::centrify::install': } ->

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -21,7 +21,7 @@ describe 'centrify' do
             })
           end
           it do
-            is_expected.to contain_file('centrifydc_sshd_config').with({
+            is_expected.to contain_file('centrifydc_sshd_config').only_with({
               'ensure' => 'file',
               'path'   => '/etc/centrifydc/ssh/sshd_config',
               'owner'  => 'root',
@@ -51,7 +51,7 @@ describe 'centrify' do
             })
           end
 
-          it do 
+          it do
             is_expected.to contain_centrifydc_line('pam.allow.users').with({
               'ensure' => 'present',
               'value'  => 'file:/etc/centrifydc/users.allow'
@@ -74,7 +74,7 @@ describe 'centrify' do
             })
           end
 
-          it do 
+          it do
             is_expected.to contain_centrifydc_line('pam.allow.groups').with({
               'ensure' => 'present',
               'value'  => 'file:/etc/centrifydc/groups.allow'
@@ -97,7 +97,7 @@ describe 'centrify' do
             })
           end
 
-          it do 
+          it do
             is_expected.to contain_centrifydc_line('pam.deny.users').with({
               'ensure' => 'present',
               'value'  => 'file:/etc/centrifydc/users.deny'
@@ -120,7 +120,7 @@ describe 'centrify' do
             })
           end
 
-          it do 
+          it do
             is_expected.to contain_centrifydc_line('pam.deny.groups').with({
               'ensure' => 'present',
               'value'  => 'file:/etc/centrifydc/groups.deny'
@@ -131,6 +131,103 @@ describe 'centrify' do
             is_expected.to contain_file('deny_groups_file').with_content(
               /bad_group1\nbad_group2/
             )
+          end
+        end
+
+        context "centrify::config class with sshd_config_content specified" do
+          let(:params) do
+            {
+              :sshd_config_content => 'centrify_test',
+            }
+          end
+          it do
+            is_expected.to contain_file('centrifydc_sshd_config').with({
+              'ensure'  => 'file',
+              'path'    => '/etc/centrifydc/ssh/sshd_config',
+              'content' => /^centrify_test$/
+            })
+          end
+        end
+
+        context "centrify::config class with sshd_config_template specified" do
+          let(:params) do
+            {
+              :sshd_config_template => 'test/sshd_config.erb',
+            }
+          end
+          it do
+            is_expected.to contain_file('centrifydc_sshd_config').with({
+              'ensure'  => 'file',
+              'path'    => '/etc/centrifydc/ssh/sshd_config',
+              'content' => /^centrify_test$/
+            })
+          end
+        end
+
+        context "centrify::config class with sshd_config_source specified" do
+          let(:params) do
+            {
+              :sshd_config_source => 'puppet:///modules/profile/centrify/sshd_config.erb',
+            }
+          end
+          it do
+            is_expected.to contain_file('centrifydc_sshd_config').with({
+              'ensure'  => 'file',
+              'path'    => '/etc/centrifydc/ssh/sshd_config',
+              'source'  => 'puppet:///modules/profile/centrify/sshd_config.erb',
+            })
+          end
+        end
+
+        context "centrify::config class with manage_sshd_config=false" do
+          let(:params) do
+            {
+              :manage_sshd_config => false,
+            }
+          end
+          it do
+            is_expected.not_to contain_file('centrifydc_sshd_config')
+          end
+        end
+
+        context "centrify::config class with sshd_config_content and sshd_config_template specified" do
+          let(:params) do
+            {
+              :sshd_config_content  => {
+                'TestKey'     => 'TheValue',
+                'AnotherTest' => 'AnotherValue',
+              },
+              :sshd_config_template => 'test/sshd_config_content.erb',
+            }
+          end
+          it do
+            is_expected.to contain_file('centrifydc_sshd_config').with({
+              'content' => /^TestKey TheValue\nAnotherTest AnotherValue$/
+            })
+          end
+        end
+
+        context "centrify::config class with sshd_config_content and sshd_config_source specified" do
+          let(:params) do
+            {
+              :sshd_config_content => 'centrify_test',
+              :sshd_config_source  => 'puppet:///modules/test/sshd_config.erb',
+            }
+          end
+          it do
+            is_expected.to raise_error(Puppet::Error, /Cannot set sshd_config_source and sshd_config_content or sshd_config_template/)
+          end
+        end
+
+        context "centrify::config class with sshd_config_template and sshd_config_source specified" do
+          let(:params) do
+            {
+              :sshd_config_template => 'test/sshd_config.erb',
+              :sshd_config_source   => 'puppet:///modules/test/sshd_config.erb',
+            }
+          end
+          it do
+            is_expected.to raise_error(Puppet::Error, /Cannot set sshd_config_source and sshd_config_content or sshd_config_template/)
           end
         end
       end

--- a/spec/fixtures/modules/test/templates/sshd_config.erb
+++ b/spec/fixtures/modules/test/templates/sshd_config.erb
@@ -1,0 +1,1 @@
+centrify_test

--- a/spec/fixtures/modules/test/templates/sshd_config_content.erb
+++ b/spec/fixtures/modules/test/templates/sshd_config_content.erb
@@ -1,0 +1,3 @@
+<%- @sshd_config_content.each do |k,v| -%>
+<%= k %> <%= v %>
+<%- end -%>


### PR DESCRIPTION
* This adds parameters to optionally manage the contents of the Centrify
sshd_config file and a boolean parameter to toggle managing the file by
this module at all. Prior to this, the module managed the sshd_config,
but it was not optional and there were no parameters to specify content
or source.

* The `centrify::manage_sshd_config` parameter takes a boolean to determine
whether the module should manage the sshd_config file or not.

* Three new parameters can be used to specify the contents of the
sshd_config:
  * `sshd_config_content`: String, Hash, or Array. Passed to the
  `sshd_config_file` resource's `content` parameter. If
  `sshd_config_template` is specified, it takes precedence, but the
  `sshd_config_content` can be referenced in the custom template via a
  locally scoped variable called `sshd_config_content` (e.g. pass
  contents as a Hash, then iterate over it with a custom template).
  * `sshd_config_template`: Passed to the `template()` function for the
  `content` parameter value for the `sshd_config_file` file resource.
  * `sshd_config_source`: Takes any valid `source` for the
  `sshd_config_file` file resource, such as a Puppet URI or a local file
  path. An error will be raised if this parameter is set in addition to
  `sshd_config_template` or `sshd_config_content`.

Example use:

```puppet
class { 'centrify':
  sshd_config_content => 'Just a string in the file',
}
```

Specify both `sshd_config_content` and `sshd_config_template`. The
template will be used, but the `sshd_config_content` can be referenced
within the template by a local scope variable called
`sshd_config_content`:

```puppet
$sshd_config_hash = {
  'AllowGroups' => 'admins ssh-users',
  'Port'        => '22',
}

class { 'centrify':
  sshd_config_content  => $sshd_config_hash,
  sshd_config_template => 'profile/centrify/centrify_sshd_config.erb',
}
```

Specifying via a Puppet URI:

```puppet
class { 'centrify':
  sshd_config_source =>
  'puppet:///modules/profile/centrify/sshd_config',
}
```