### PR TITLE
Un-quote environment variable setting

### DIFF
--- a/manifests/adjoin/password.pp
+++ b/manifests/adjoin/password.pp
@@ -46,7 +46,7 @@ class centrify::adjoin::password (
     exec { 'adjoin_precreate_with_password':
       path        => '/usr/bin:/usr/sbin:/bin',
       command     => "${_command} -P",
-      environment => "CENTRIFY_JOIN_PASSWORD='${join_password}'",
+      environment => "CENTRIFY_JOIN_PASSWORD=${join_password}",
       unless      => "adinfo -d | grep ${domain}",
       before      => Exec['adjoin_with_password'],
     }
@@ -55,7 +55,7 @@ class centrify::adjoin::password (
   exec { 'adjoin_with_password':
     path        => '/usr/bin:/usr/sbin:/bin',
     command     => $_command,
-    environment => "CENTRIFY_JOIN_PASSWORD='${join_password}'",
+    environment => "CENTRIFY_JOIN_PASSWORD=${join_password}",
     unless      => "adinfo -d | grep ${domain}",
     notify      => Exec['run_adflush_and_adreload'],
   }

--- a/spec/classes/adjoin__password_spec.rb
+++ b/spec/classes/adjoin__password_spec.rb
@@ -24,7 +24,7 @@ describe 'centrify' do
             is_expected.to contain_exec('adjoin_with_password').with({
               'path'        => '/usr/bin:/usr/sbin:/bin',
               'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com'",
-              'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+              'environment' => "CENTRIFY_JOIN_PASSWORD=password",
               'unless'      => 'adinfo -d | grep example.com',
             })
           end
@@ -47,7 +47,7 @@ describe 'centrify' do
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
                 'command'     => "adjoin -V -z 'ZONE' -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com'",
-                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD=password",
               })
             end
           end
@@ -62,7 +62,7 @@ describe 'centrify' do
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
                 'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD -c 'ou=Unix computers' 'example.com'",
-                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD=password",
               })
             end
           end
@@ -77,7 +77,7 @@ describe 'centrify' do
             it do
               is_expected.to contain_exec('adjoin_with_password').with({
                 'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD --name foobar 'example.com'",
-                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD=password",
               })
             end
           end
@@ -92,7 +92,7 @@ describe 'centrify' do
             it do
               is_expected.to contain_exec('adjoin_precreate_with_password').with({
                 'command'     => "adjoin -V -w -u 'user' -p $CENTRIFY_JOIN_PASSWORD 'example.com' -P",
-                'environment' => "CENTRIFY_JOIN_PASSWORD='password'",
+                'environment' => "CENTRIFY_JOIN_PASSWORD=password",
               })
             end
           end


### PR DESCRIPTION
The `CENTRIFY_JOIN_PASSWORD` were unnecessarily single-quoted in PR#9.
This caused a failure, as the environment variable value appeared to be blank. This
removes the single quote surrounds.