### PR TITLE
Module does not detect if machine is already joined

### DIFF
--- a/manifests/adjoin/keytab.pp
+++ b/manifests/adjoin/keytab.pp
@@ -69,18 +69,19 @@ class centrify::adjoin::keytab (
   $_join_opts = delete(concat($_opts, $extra_args), '')
   $_options   = join($_join_opts, ' ')
   $_command   = "adjoin ${_options} '${domain}'"
+  $_is_joined = "adinfo -d | grep ${domain.downcase()}"
 
   exec { 'run_kinit_with_keytab':
     path    => '/usr/share/centrifydc/kerberos/bin:/usr/bin:/usr/sbin:/bin',
     command => "kinit -kt ${krb_keytab} ${join_user}",
-    unless  => "adinfo -d | grep ${domain}",
+    unless  => $_is_joined,
   }
 
   if $precreate {
     exec { 'run_adjoin_precreate_with_keytab':
       path    => '/usr/bin:/usr/sbin:/bin',
       command => "${_command} -P",
-      unless  => "adinfo -d | grep ${domain}",
+      unless  => $_is_joined,
       require => Exec['run_kinit_with_keytab'],
       before  => Exec['run_adjoin_with_keytab'],
     }
@@ -89,7 +90,7 @@ class centrify::adjoin::keytab (
   exec { 'run_adjoin_with_keytab':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => $_command,
-    unless  => "adinfo -d | grep ${domain}",
+    unless  => $_is_joined,
     require => Exec['run_kinit_with_keytab'],
     notify  => Exec['run_adflush_and_adreload'],
   }

--- a/manifests/adjoin/password.pp
+++ b/manifests/adjoin/password.pp
@@ -41,13 +41,14 @@ class centrify::adjoin::password (
   $_join_opts = delete(concat($_opts, $extra_args), '')
   $_options   = join($_join_opts, ' ')
   $_command   = "adjoin ${_options} '${domain}'"
+  $_is_joined = "adinfo -d | grep ${domain.downcase()}"
 
   if $precreate {
     exec { 'adjoin_precreate_with_password':
       path        => '/usr/bin:/usr/sbin:/bin',
       command     => "${_command} -P",
       environment => "CENTRIFY_JOIN_PASSWORD=${join_password}",
-      unless      => "adinfo -d | grep ${domain}",
+      unless      => $_is_joined,
       before      => Exec['adjoin_with_password'],
     }
   }
@@ -56,7 +57,7 @@ class centrify::adjoin::password (
     path        => '/usr/bin:/usr/sbin:/bin',
     command     => $_command,
     environment => "CENTRIFY_JOIN_PASSWORD=${join_password}",
-    unless      => "adinfo -d | grep ${domain}",
+    unless      => $_is_joined,
     notify      => Exec['run_adflush_and_adreload'],
   }
 

--- a/manifests/adjoin/selfserve.pp
+++ b/manifests/adjoin/selfserve.pp
@@ -24,11 +24,12 @@ class centrify::adjoin::selfserve (
   $_join_opts = delete(concat($_opts, $extra_args), '')
   $_options   = join($_join_opts, ' ')
   $_command   = "adjoin ${_options} '${domain}'"
+  $_is_joined = "adinfo -d | grep ${domain.downcase()}"
 
   exec { 'adjoin_with_selfserve':
     path    => '/usr/bin:/usr/sbin:/bin',
     command => $_command,
-    unless  => "adinfo -d | grep ${domain}",
+    unless  => $_is_joined,
     notify  => Exec['run_adflush_and_adreload'],
   }
 


### PR DESCRIPTION
I'm trying to use this module to set-up Centrify in a previously mixed environments. On machines that already have centrify registered, the module fails.

How can I configure this such that provisioning works correctly (does a selfserve join), but then does not attempt to do it on machines that are already successfully joined.

> notice	/Stage[main]/Centrify::Adjoin::Selfserve/Exec[adjoin_with_selfserve]/returns	Error: this computer is already joined to the domain.
> notice	/Stage[main]/Centrify::Adjoin::Selfserve/Exec[adjoin_with_selfserve]/returns	Use adleave first.
> err	Puppet	adjoin -w -V --selfserve 'EXAMPLE.COM' returned 11 instead of one of [0]
> err	/Stage[main]/Centrify::Adjoin::Selfserve/Exec[adjoin_with_selfserve]/returns	change from notrun to 0 failed: adjoin -w -V --selfserve 'EXAMPLE.COM' returned 11 instead of one of [0]

Perhaps checking adinfo first?
```
$ adinfo
Local host name:   test-foo-01
Joined to domain:  example.com
Joined as:         test-foo-01.example.com
Pre-win2K name:    test-foo-01
Current DC:        dev-ad-01.example.com
Preferred site:    Site-Examplecom
Zone:              Auto Zone
CentrifyDC mode:   connected
Licensed Features: Disabled
```

Parameters:
```
  centrify:
    domain: EXAMPLE.COM
    join_type: selfserve
    use_express_license: true
```